### PR TITLE
Integration tests fix: deploy Monetha contracts only once.

### DIFF
--- a/integration-tests/test/deployContracts.ts
+++ b/integration-tests/test/deployContracts.ts
@@ -1,0 +1,67 @@
+import { getAccount } from '../common/network';
+
+const PassportLogic = artifacts.require('PassportLogic');
+const PassportLogicRegistry = artifacts.require('PassportLogicRegistry');
+const PassportFactory = artifacts.require('PassportFactory');
+const FactProviderRegistryArtifact = artifacts.require('FactProviderRegistry');
+
+export enum Contract {
+  PassportLogic = 'PassportLogic',
+  PassportLogicRegistry = 'PassportLogicRegistry',
+  PassportFactory = 'PassportFactory',
+  FactProviderRegistryArtifact = 'FactProviderRegistryArtifact',
+}
+
+const deployedContracts = new Map<Contract, any>();
+
+export const deployContract = async (contract: Contract, contractCreationParams?: any) => {
+  const monethaOwner = await getAccount(web3, 0);
+  const registryOwner = monethaOwner;
+
+  const deployedContract = deployedContracts.get(contract);
+  if (deployedContract) {
+    return deployedContract;
+  }
+
+  switch (contract) {
+    case Contract.PassportLogic:
+      const passportLogic = await PassportLogic.new({ from: monethaOwner, ...contractCreationParams });
+      deployedContracts.set(Contract.PassportLogic, passportLogic);
+      return passportLogic;
+
+    case Contract.PassportLogicRegistry:
+      if (!deployedContracts.get(Contract.PassportLogic)) {
+        throw new Error(`${Contract.PassportLogic} was not deployed yet.`);
+      }
+
+      const passportLogicRegistry = await PassportLogicRegistry.new(
+        '0.1',
+        deployedContracts.get(Contract.PassportLogic).address,
+        { from: monethaOwner, ...contractCreationParams },
+      );
+
+      deployedContracts.set(Contract.PassportLogicRegistry, passportLogicRegistry);
+      return passportLogicRegistry;
+
+    case Contract.PassportFactory:
+      if (!deployedContracts.get(Contract.PassportLogicRegistry)) {
+        throw new Error(`${Contract.PassportLogicRegistry} was not deployed yet.`);
+      }
+
+      const passportFactory = await PassportFactory.new(
+        deployedContracts.get(Contract.PassportLogicRegistry).address,
+        { from: monethaOwner, ...contractCreationParams },
+      );
+
+      deployedContracts.set(Contract.PassportFactory, passportFactory);
+      return passportFactory;
+
+    case Contract.FactProviderRegistryArtifact:
+      const factProviderRegistry = await FactProviderRegistryArtifact.new({ from: registryOwner, ...contractCreationParams });
+      deployedContracts.set(Contract.FactProviderRegistryArtifact, factProviderRegistry);
+      return factProviderRegistry;
+
+    default:
+      throw new Error(`Unknown contract: ${contract}`);
+  }
+};

--- a/integration-tests/test/factProviderRegistry.ts
+++ b/integration-tests/test/factProviderRegistry.ts
@@ -1,11 +1,9 @@
 import { logVerbose } from 'common/logger';
 import { getAccount, getNetwork, getNetworkNodeUrl, getNodePublicKey, getPrivateKey, NetworkType } from 'common/network';
 import { isPrivateTxMode, createTxExecutor } from 'common/tx';
-import { FactProviderRegistry } from 'lib/types/web3-contracts/FactProviderRegistry';
 import { Address, FactProviderManager, IFactProviderInfo } from 'verifiable-data';
 import Web3 from 'web3';
-
-const FactProviderRegistryArtifact = artifacts.require('FactProviderRegistry');
+import { Contract, deployContract } from './deployContracts';
 
 const web3 = new Web3(new Web3.providers.HttpProvider(getNetworkNodeUrl()));
 const contractCreationParams: any = {};
@@ -13,7 +11,6 @@ const txExecutor = createTxExecutor(web3);
 
 let registryOwner: string;
 let registryOwnerPrivateKey: string;
-let registry: FactProviderRegistry;
 let registryAddress: string;
 let factProvider1: Address;
 let factProvider2: Address;
@@ -49,7 +46,7 @@ before(async () => {
   }
 
   // Deploy contracts
-  registry = await FactProviderRegistryArtifact.new({ from: registryOwner, ...contractCreationParams });
+  const registry = await deployContract(Contract.FactProviderRegistryArtifact, contractCreationParams);
   registryAddress = registry.address;
 
   logVerbose('----------------------------------------------------------');

--- a/integration-tests/test/facts.ts
+++ b/integration-tests/test/facts.ts
@@ -1,9 +1,28 @@
 import { logVerbose } from 'common/logger';
-import { getAccount, getNetwork, getNetworkNodeUrl, getPrivateKey, NetworkType, getNodePublicKey } from 'common/network';
+import {
+  getAccount,
+  getNetwork,
+  getNetworkNodeUrl,
+  getNodePublicKey,
+  getPrivateKey,
+  NetworkType,
+} from 'common/network';
 import { createTxExecutor, isPrivateTxMode } from 'common/tx';
-import { ext, FactHistoryReader, FactReader, FactRemover, FactWriter, IEthOptions, PassportGenerator, PassportOwnership, PassportReader, Permissions } from 'verifiable-data';
+import {
+  ext,
+  FactHistoryReader,
+  FactReader,
+  FactRemover,
+  FactWriter,
+  IEthOptions,
+  PassportGenerator,
+  PassportOwnership,
+  PassportReader,
+  Permissions,
+} from 'verifiable-data';
 import Web3 from 'web3';
 import { MockIPFSClient } from '../mocks/MockIPFSClient';
+import { Contract, deployContract } from './deployContracts';
 
 let passportLogic;
 let passportLogicRegistry;
@@ -11,7 +30,6 @@ let passportFactory;
 let passportLogicAddress;
 let passportLogicRegistryAddress;
 let passportFactoryAddress;
-let monethaOwner;
 let passportOwner;
 let passportOwnerPrivateKey;
 let passportAddress;
@@ -31,7 +49,6 @@ const txHashes: any = {};
 const txExecutor = createTxExecutor(web3);
 
 before(async () => {
-  monethaOwner = await getAccount(web3, 0);
   passportOwner = await getAccount(web3, 1);
   passportOwnerPrivateKey = getPrivateKey(1);
   factProviderAddress = await getAccount(web3, 2);
@@ -51,11 +68,11 @@ before(async () => {
   }
 
   // deploy contracts
-  passportLogic = await PassportLogic.new({ from: monethaOwner, ...contractCreationParams });
+  passportLogic = await deployContract(Contract.PassportLogic, contractCreationParams);
   passportLogicAddress = passportLogic.address;
-  passportLogicRegistry = await PassportLogicRegistry.new('0.1', passportLogic.address, { from: monethaOwner, ...contractCreationParams });
+  passportLogicRegistry = await deployContract(Contract.PassportLogicRegistry, contractCreationParams);
   passportLogicRegistryAddress = passportLogicRegistry.address;
-  passportFactory = await PassportFactory.new(passportLogicRegistry.address, { from: monethaOwner, ...contractCreationParams });
+  passportFactory = await deployContract(Contract.PassportFactory, contractCreationParams);
   passportFactoryAddress = passportFactory.address;
 
   logVerbose('----------------------------------------------------------');

--- a/integration-tests/test/privateDataExchange.ts
+++ b/integration-tests/test/privateDataExchange.ts
@@ -2,13 +2,31 @@ import BN from 'bn.js';
 import { expectSdkError } from 'common/error';
 import { advanceTimeAndBlock, revertToSnapshot, takeSnapshot } from 'common/networks/ganache';
 import { createTxExecutor, isPrivateTxMode } from 'common/tx';
-import { FactWriter, PassportGenerator, PassportOwnership, PrivateDataExchanger, Address, IEthOptions, ext, ExchangeState, ErrorCode, ISKM } from 'verifiable-data';
+import {
+  Address,
+  ErrorCode,
+  ExchangeState,
+  ext,
+  FactWriter,
+  IEthOptions,
+  ISKM,
+  PassportGenerator,
+  PassportOwnership,
+  PrivateDataExchanger,
+} from 'verifiable-data';
 import { MockIPFSClient } from 'mocks/MockIPFSClient';
 import Web3 from 'web3';
-import { getNetworkNodeUrl, getPrivateKey, getAccount, getNetwork, NetworkType, getNodePublicKey } from 'common/network';
+import {
+  getAccount,
+  getNetwork,
+  getNetworkNodeUrl,
+  getNodePublicKey,
+  getPrivateKey,
+  NetworkType,
+} from 'common/network';
 import { logVerbose } from 'common/logger';
+import { Contract, deployContract } from './deployContracts';
 
-let monethaOwner: Address;
 let passportOwner: Address;
 let passportOwnerPrivateKey: string;
 let passportFactoryAddress;
@@ -59,7 +77,6 @@ let exchangeData: any = {};
 const preparePassport = async () => {
 
   // Accounts
-  monethaOwner = await getAccount(web3, 0);
   passportOwner = await getAccount(web3, 1);
   passportOwnerPrivateKey = getPrivateKey(1);
   factProviderAddress = await getAccount(web3, 2);
@@ -67,9 +84,9 @@ const preparePassport = async () => {
   requesterPrivateKey = getPrivateKey(3);
   otherPersonAddress = await getAccount(web3, 4);
 
-  const passportLogic = await PassportLogic.new({ from: monethaOwner, ...contractCreationParams });
-  const passportLogicRegistry = await PassportLogicRegistry.new('0.1', passportLogic.address, { from: monethaOwner, ...contractCreationParams });
-  const passportFactory = await PassportFactory.new(passportLogicRegistry.address, { from: monethaOwner, ...contractCreationParams });
+  const passportLogic = await deployContract(Contract.PassportLogic, contractCreationParams);
+  const passportLogicRegistry = await deployContract(Contract.PassportLogicRegistry, contractCreationParams);
+  const passportFactory = await deployContract(Contract.PassportFactory, contractCreationParams);
   passportFactoryAddress = passportFactory.address;
 
   // Create passport


### PR DESCRIPTION
Deploy contracts (PassportLogic, PassportLogicRegistry, PassportFactory, FactProviderRegistry) only once with predefined monethaOwner.